### PR TITLE
add refund apis

### DIFF
--- a/client/base/store_def.go
+++ b/client/base/store_def.go
@@ -28,6 +28,12 @@ const (
 	HubListOrderPage = "/xasset/trade/v1/order_page"
 	CountOrder       = "/xasset/trade/v1/count_order"
 	SumOrderPrice    = "/xasset/trade/v1/sum_order_price"
+
+	CheckRefund   = "/xasset/trade/v1/checkrefund"
+	CreateRefund  = "/xasset/trade/v1/refund"
+	CancelRefund  = "/xasset/trade/v1/cancelrefund"
+	ConfirmRefund = "/xasset/trade/v1/confirmrefund"
+	RefuseRefund  = "/xasset/trade/v1/refuserefund"
 )
 
 // ///// Create Store /////////
@@ -544,4 +550,96 @@ type SumOrderPriceData struct {
 type SumOrderPriceResp struct {
 	BaseResp
 	Data SumOrderPriceData `json:"data"`
+}
+
+type CheckRefundParam struct {
+	Oid int64 `json:"oid"`
+}
+
+func (p *CheckRefundParam) Valid() error {
+	if p.Oid < 1 {
+		return fmt.Errorf("oid invalid")
+	}
+	return nil
+}
+
+type CheckRefundData struct {
+	Refundable   int `json:"refundable"`
+	RefuseReason int `json:"refuse_reason"`
+}
+
+type CheckRefundResp struct {
+	BaseResp
+	Data CheckRefundData `json:"data"`
+}
+
+type CreateRefundParam struct {
+	Oid     int64  `json:"oid"`
+	Address string `json:"address"`
+	Reason  string `json:"reason"`
+}
+
+func (p *CreateRefundParam) Valid() error {
+	if p.Oid < 1 {
+		return fmt.Errorf("oid invalid")
+	}
+	return nil
+}
+
+type CreateRefundData struct {
+	Rid          int64 `json:"rid"`
+	Refundable   int   `json:"refundable"`
+	RefuseReason int   `json:"refuse_reason"`
+}
+
+type CreateRefundResp struct {
+	BaseResp
+	Data CreateRefundData `json:"data"`
+}
+
+type CancelRefundParam struct {
+	Rid     int64  `json:"oid"`
+	Address string `json:"address"`
+}
+
+func (p *CancelRefundParam) Valid() error {
+	if p.Rid < 1 {
+		return fmt.Errorf("rid invalid")
+	}
+	return nil
+}
+
+type CancelRefundData struct {
+	Rid int64 `json:"rid"`
+}
+
+type CancelRefundResp struct {
+	BaseResp
+	Data CancelRefundData `json:"data"`
+}
+
+type ConfirmRefundParam struct {
+	Rid      int64  `json:"rid"`
+	Message  string `json:"message"`
+	Operator string `json:"operator"`
+}
+
+func (p *ConfirmRefundParam) Valid() error {
+	if p.Rid < 1 {
+		return fmt.Errorf("rid invalid")
+	}
+	return nil
+}
+
+type RefuseRefundParam struct {
+	Rid      int64  `json:"rid"`
+	Message  string `json:"message"`
+	Operator string `json:"operator"`
+}
+
+func (p *RefuseRefundParam) Valid() error {
+	if p.Rid < 1 {
+		return fmt.Errorf("rid invalid")
+	}
+	return nil
 }

--- a/client/xstore/store.go
+++ b/client/xstore/store.go
@@ -1135,3 +1135,200 @@ func (t *StoreOper) GenSecretData(data string) (string, error) {
 	key := fmt.Sprintf("%X", digest)
 	return utils.AesEncode(data, key)
 }
+
+// CheckRefund check order refundable
+func (t *StoreOper) CheckRefund(param *xbase.CheckRefundParam) (*xbase.CheckRefundResp, *xbase.RequestRes, error) {
+	if err := param.Valid(); err != nil {
+		return nil, nil, xbase.ErrParamInvalid
+	}
+	v := url.Values{}
+	v.Set("oid", fmt.Sprintf("%d", param.Oid))
+
+	body := v.Encode()
+	res, err := t.Post(xbase.CheckRefund, body)
+	if err != nil {
+		t.Logger.Warn("post request xasset failed, uri: %s, err: %v", xbase.SumOrderPrice, err)
+		return nil, nil, xbase.ComErrRequsetFailed
+	}
+	if res.HttpCode != 200 {
+		t.Logger.Warn("post request response is not 200. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, nil, xbase.ComErrRespCodeErr
+	}
+
+	var resp xbase.CheckRefundResp
+	err = json.Unmarshal([]byte(res.Body), &resp)
+	if err != nil {
+		t.Logger.Warn("unmarshal body failed. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrUnmarshalBodyFailed
+	}
+	if resp.Errno != xbase.XassetErrNoSucc {
+		t.Logger.Warn("get resp failed. [url: %s] [request_id: %s] [err_no: %d] [trace_id: %s]",
+			res.ReqUrl, resp.RequestId, resp.Errno, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrServRespErrnoErr
+	}
+
+	t.Logger.Trace("operate succ. [param: %+v] [url: %s] [request_id: %s] [trace_id: %s]",
+		param, res.ReqUrl, resp.RequestId, t.GetTarceId(res.Header))
+	return &resp, res, nil
+}
+
+// CreateRefund create a refund order
+func (t *StoreOper) CreateRefund(param *xbase.CreateRefundParam) (*xbase.CreateRefundResp, *xbase.RequestRes, error) {
+	if err := param.Valid(); err != nil {
+		return nil, nil, xbase.ErrParamInvalid
+	}
+	v := url.Values{}
+	v.Set("oid", fmt.Sprintf("%d", param.Oid))
+	v.Set("address", param.Address)
+	v.Set("reason", param.Reason)
+
+	body := v.Encode()
+	res, err := t.Post(xbase.CreateRefund, body)
+	if err != nil {
+		t.Logger.Warn("post request xasset failed, uri: %s, err: %v", xbase.SumOrderPrice, err)
+		return nil, nil, xbase.ComErrRequsetFailed
+	}
+	if res.HttpCode != 200 {
+		t.Logger.Warn("post request response is not 200. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, nil, xbase.ComErrRespCodeErr
+	}
+
+	var resp xbase.CreateRefundResp
+	err = json.Unmarshal([]byte(res.Body), &resp)
+	if err != nil {
+		t.Logger.Warn("unmarshal body failed. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrUnmarshalBodyFailed
+	}
+	if resp.Errno != xbase.XassetErrNoSucc {
+		t.Logger.Warn("get resp failed. [url: %s] [request_id: %s] [err_no: %d] [trace_id: %s]",
+			res.ReqUrl, resp.RequestId, resp.Errno, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrServRespErrnoErr
+	}
+
+	t.Logger.Trace("operate succ. [param: %+v] [url: %s] [request_id: %s] [trace_id: %s]",
+		param, res.ReqUrl, resp.RequestId, t.GetTarceId(res.Header))
+	return &resp, res, nil
+}
+
+// CancelRefund cancel a refund order
+func (t *StoreOper) CancelRefund(param *xbase.CancelRefundParam) (*xbase.BaseResp, *xbase.RequestRes, error) {
+	if err := param.Valid(); err != nil {
+		return nil, nil, xbase.ErrParamInvalid
+	}
+	v := url.Values{}
+	v.Set("rid", fmt.Sprintf("%d", param.Rid))
+	v.Set("address", param.Address)
+
+	body := v.Encode()
+	res, err := t.Post(xbase.CancelRefund, body)
+	if err != nil {
+		t.Logger.Warn("post request xasset failed, uri: %s, err: %v", xbase.SumOrderPrice, err)
+		return nil, nil, xbase.ComErrRequsetFailed
+	}
+	if res.HttpCode != 200 {
+		t.Logger.Warn("post request response is not 200. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, nil, xbase.ComErrRespCodeErr
+	}
+
+	var resp xbase.BaseResp
+	err = json.Unmarshal([]byte(res.Body), &resp)
+	if err != nil {
+		t.Logger.Warn("unmarshal body failed. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrUnmarshalBodyFailed
+	}
+	if resp.Errno != xbase.XassetErrNoSucc {
+		t.Logger.Warn("get resp failed. [url: %s] [request_id: %s] [err_no: %d] [trace_id: %s]",
+			res.ReqUrl, resp.RequestId, resp.Errno, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrServRespErrnoErr
+	}
+
+	t.Logger.Trace("operate succ. [param: %+v] [url: %s] [request_id: %s] [trace_id: %s]",
+		param, res.ReqUrl, resp.RequestId, t.GetTarceId(res.Header))
+	return &resp, res, nil
+}
+
+// ConfirmRefund pass a refund order
+func (t *StoreOper) ConfirmRefund(param *xbase.ConfirmRefundParam) (*xbase.BaseResp, *xbase.RequestRes, error) {
+	if err := param.Valid(); err != nil {
+		return nil, nil, xbase.ErrParamInvalid
+	}
+	v := url.Values{}
+	v.Set("rid", fmt.Sprintf("%d", param.Rid))
+	v.Set("message", param.Message)
+	v.Set("operator", param.Operator)
+
+	body := v.Encode()
+	res, err := t.Post(xbase.ConfirmRefund, body)
+	if err != nil {
+		t.Logger.Warn("post request xasset failed, uri: %s, err: %v", xbase.SumOrderPrice, err)
+		return nil, nil, xbase.ComErrRequsetFailed
+	}
+	if res.HttpCode != 200 {
+		t.Logger.Warn("post request response is not 200. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, nil, xbase.ComErrRespCodeErr
+	}
+
+	var resp xbase.BaseResp
+	err = json.Unmarshal([]byte(res.Body), &resp)
+	if err != nil {
+		t.Logger.Warn("unmarshal body failed. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrUnmarshalBodyFailed
+	}
+	if resp.Errno != xbase.XassetErrNoSucc {
+		t.Logger.Warn("get resp failed. [url: %s] [request_id: %s] [err_no: %d] [trace_id: %s]",
+			res.ReqUrl, resp.RequestId, resp.Errno, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrServRespErrnoErr
+	}
+
+	t.Logger.Trace("operate succ. [param: %+v] [url: %s] [request_id: %s] [trace_id: %s]",
+		param, res.ReqUrl, resp.RequestId, t.GetTarceId(res.Header))
+	return &resp, res, nil
+}
+
+// RefuseRefund refuse a refund order
+func (t *StoreOper) RefuseRefund(param *xbase.RefuseRefundParam) (*xbase.BaseResp, *xbase.RequestRes, error) {
+	if err := param.Valid(); err != nil {
+		return nil, nil, xbase.ErrParamInvalid
+	}
+	v := url.Values{}
+	v.Set("rid", fmt.Sprintf("%d", param.Rid))
+	v.Set("message", param.Message)
+	v.Set("operator", param.Operator)
+
+	body := v.Encode()
+	res, err := t.Post(xbase.RefuseRefund, body)
+	if err != nil {
+		t.Logger.Warn("post request xasset failed, uri: %s, err: %v", xbase.SumOrderPrice, err)
+		return nil, nil, xbase.ComErrRequsetFailed
+	}
+	if res.HttpCode != 200 {
+		t.Logger.Warn("post request response is not 200. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, nil, xbase.ComErrRespCodeErr
+	}
+
+	var resp xbase.BaseResp
+	err = json.Unmarshal([]byte(res.Body), &resp)
+	if err != nil {
+		t.Logger.Warn("unmarshal body failed. [http_code: %d] [url: %s] [body: %s] [trace_id: %s]",
+			res.HttpCode, res.ReqUrl, res.Body, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrUnmarshalBodyFailed
+	}
+	if resp.Errno != xbase.XassetErrNoSucc {
+		t.Logger.Warn("get resp failed. [url: %s] [request_id: %s] [err_no: %d] [trace_id: %s]",
+			res.ReqUrl, resp.RequestId, resp.Errno, t.GetTarceId(res.Header))
+		return nil, res, xbase.ComErrServRespErrnoErr
+	}
+
+	t.Logger.Trace("operate succ. [param: %+v] [url: %s] [request_id: %s] [trace_id: %s]",
+		param, res.ReqUrl, resp.RequestId, t.GetTarceId(res.Header))
+	return &resp, res, nil
+}

--- a/client/xstore/store_test.go
+++ b/client/xstore/store_test.go
@@ -27,3 +27,72 @@ func TestListAct(t *testing.T) {
 
 	fmt.Println(resp.List[0])
 }
+
+func TestStoreOper_CheckRefund(t *testing.T) {
+	param := &base.CheckRefundParam{
+		Oid: 1,
+	}
+	handle, _ := NewXstoreOper(base.TestGetXassetConfig(), &base.TestLogger{})
+	resp, _, err := handle.CheckRefund(param)
+	if err != nil {
+		t.Errorf("check order refundable error.err:%v", err)
+		return
+	}
+	fmt.Println(resp)
+}
+
+func TestStoreOper_CreateRefund(t *testing.T) {
+	param := &base.CreateRefundParam{
+		Oid:     1,
+		Address: "xx",
+		Reason:  "refund",
+	}
+	handle, _ := NewXstoreOper(base.TestGetXassetConfig(), &base.TestLogger{})
+	resp, _, err := handle.CreateRefund(param)
+	if err != nil {
+		t.Errorf("create refund error.err:%v", err)
+		return
+	}
+	fmt.Println(resp)
+}
+
+func TestStoreOper_CancelRefund(t *testing.T) {
+	param := &base.CancelRefundParam{
+		Rid:     1,
+		Address: "xx",
+	}
+	handle, _ := NewXstoreOper(base.TestGetXassetConfig(), &base.TestLogger{})
+	resp, _, err := handle.CancelRefund(param)
+	if err != nil {
+		t.Errorf("cancel refund error.err:%v", err)
+		return
+	}
+	fmt.Println(resp)
+}
+
+func TestStoreOper_ConfirmRefund(t *testing.T) {
+	param := &base.ConfirmRefundParam{
+		Rid: 1,
+	}
+	handle, _ := NewXstoreOper(base.TestGetXassetConfig(), &base.TestLogger{})
+	resp, _, err := handle.ConfirmRefund(param)
+	if err != nil {
+		t.Errorf("confirm refund error.err:%v", err)
+		return
+	}
+	fmt.Println(resp)
+}
+
+func TestStoreOper_RefuseRefund(t *testing.T) {
+	param := &base.RefuseRefundParam{
+		Rid:     1,
+		Message: "rejected",
+	}
+	handle, _ := NewXstoreOper(base.TestGetXassetConfig(), &base.TestLogger{})
+	resp, _, err := handle.RefuseRefund(param)
+	if err != nil {
+		t.Errorf("refuse refund error.err:%v", err)
+		return
+	}
+	fmt.Println(resp)
+}


### PR DESCRIPTION
## Description

add refund apis:
1. check if order refundable
2. create a refund order
3. cancel a refund order
4. pass a refund order
5. reject a refund order

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)